### PR TITLE
chore: update h11 version to 0.16.0 in requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ charset-normalizer==3.4.1
 click==8.1.8
 dotenv==0.9.9
 fastapi==0.115.11
-h11==0.14.0
+h11==0.16.0
 idna==3.10
 pydantic==2.10.6
 pydantic_core==2.27.2


### PR DESCRIPTION
This pull request updates a dependency version in the backend requirements to ensure compatibility and access to the latest features and fixes.

Dependency version update:

* Upgraded the `h11` package from version 0.14.0 to 0.16.0 in `backend/requirements.txt` to keep the HTTP library up-to-date.