### PR TITLE
ci: fix permissions on lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   backend-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration by adding explicit permissions for the workflow.

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R9-R11): Added `permissions` block to set `contents: read` for the workflow, improving security by restricting access to repository contents.